### PR TITLE
feat: add SwiftUI macOS client package

### DIFF
--- a/macos/BestAIProjectApp/Package.swift
+++ b/macos/BestAIProjectApp/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "BestAIProjectApp",
+    defaultLocalization: "en",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(
+            name: "BestAIProjectApp",
+            targets: ["BestAIProjectApp"]
+        )
+    ],
+    targets: [
+        .executableTarget(
+            name: "BestAIProjectApp",
+            path: "Sources",
+            resources: [
+                .process("BestAIProjectApp/Resources")
+            ]
+        )
+    ]
+)

--- a/macos/BestAIProjectApp/README.md
+++ b/macos/BestAIProjectApp/README.md
@@ -1,0 +1,54 @@
+# BestAIProjectApp (macOS)
+
+A native SwiftUI macOS client for the FastAPI backend in this repository. The project is structured as a Swift Package so you can open the folder directly in Xcode, run the desktop app, and iterate with the SwiftUI previews.
+
+## Features
+
+- Real-time chat streaming via the `/api/chat/stream` endpoint (Server-Sent Events)
+- Backend health indicator with manual refresh
+- Model browser with the ability to switch the active Ollama tag
+- Editable system & developer prompts and advanced generation settings
+- Optional auto-launch of the bundled Python backend so everything runs from the desktop app
+
+## Opening in Xcode
+
+1. Install Xcode 15 or newer on macOS 13 Ventura (or later).
+2. From the Xcode welcome window choose **Open a project or file…** and select the `macos/BestAIProjectApp` directory.
+3. Xcode treats Swift packages as first-class projects; pick the `BestAIProjectApp` scheme and run it on "My Mac".
+
+## Local backend workflow
+
+The SwiftUI app assumes that the FastAPI server in this repository is available on `http://127.0.0.1:8000`.
+
+- If you are already running `python server.py` (or `./start.sh`) separately you can hit **Connect** inside the macOS app to verify the connection.
+- To launch the backend directly from the macOS app, point the **Python Runtime** setting at your preferred interpreter (`/usr/bin/python3`, a virtual environment, etc.) and enable **Launch Python backend on start**. The app will spawn the server in-process and show its lifecycle status at the bottom of the sidebar.
+
+## Directory layout
+
+```
+macos/BestAIProjectApp
+├── Package.swift                # Swift Package manifest (open in Xcode)
+├── README.md
+└── Sources
+    └── BestAIProjectApp
+        ├── BestAIProjectApp.swift    # @main entry point
+        ├── AppState.swift            # ObservableObject orchestrating chat state
+        ├── Models.swift              # Shared DTOs & JSON helpers
+        ├── Services
+        │   ├── ChatService.swift     # HTTP/SSE client for the FastAPI backend
+        │   └── PythonServerManager.swift  # Launches/stops `python server.py`
+        ├── Support
+        │   └── MarkdownRenderer.swift    # Lightweight Markdown → AttributedString bridge
+        └── Views
+            ├── ContentView.swift
+            ├── ChatComposerView.swift
+            ├── ChatMessageListView.swift
+            ├── SettingsSidebarView.swift
+            └── StatusFooterView.swift
+```
+
+You can freely extend the UI or add new Swift packages inside the same folder; Xcode will detect new files automatically.
+
+## Tests
+
+The current project focuses on the UI layer. If you add model or service code that benefits from unit tests, create a `Tests/` directory next to `Sources/` and Xcode will generate a matching test target automatically.

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/AppState.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/AppState.swift
@@ -1,0 +1,234 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class AppState: ObservableObject {
+    @Published var messages: [ChatMessage] = []
+    @Published var composerText: String = ""
+    @Published var isStreaming = false
+    @Published var lastError: String?
+    @Published var healthStatus: HealthStatus?
+    @Published var models: [ModelSummary] = []
+    @Published var selectedModel: String = ""
+    @Published var settings = ChatSettings()
+    @Published var systemPrompt: String = ""
+    @Published var developerPrompt: String = ""
+    @Published var toolsEnabled: Bool = true
+    @Published var backendConfiguration: BackendConfiguration = .default {
+        didSet { persistConfiguration() }
+    }
+
+    @Published private(set) var pythonManager: PythonServerManager
+
+    private let chatService: ChatService
+    private var streamTask: Task<Void, Never>?
+    private let configurationURL: URL
+
+    init(projectRoot: URL) {
+        self.configurationURL = projectRoot.appendingPathComponent(".bestaiapp.json")
+        self.backendConfiguration = AppState.loadConfiguration(from: configurationURL) ?? .default
+        self.chatService = ChatService(baseURL: backendConfiguration.baseURL)
+        self.pythonManager = PythonServerManager(projectRoot: projectRoot)
+    }
+
+    func onAppear() {
+        if backendConfiguration.autoLaunchBackend,
+           let python = backendConfiguration.pythonInterpreter {
+            Task { await pythonManager.start(pythonInterpreter: python) }
+        }
+        Task { await refreshHealth() }
+        Task { await refreshModels() }
+    }
+
+    func send() {
+        let prompt = composerText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else { return }
+
+        composerText = ""
+        lastError = nil
+
+        let userMessage = ChatMessage(role: .user, content: prompt)
+        let historyBeforeSend = messages
+        let payloadHistory = (historyBeforeSend + [userMessage]).map { $0.payload }
+
+        messages.append(userMessage)
+        let placeholder = ChatMessage(role: .assistant, content: "", isStreaming: true)
+        messages.append(placeholder)
+        isStreaming = true
+
+        streamTask?.cancel()
+        streamTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let stream = await chatService.stream(
+                    history: payloadHistory,
+                    settings: settings,
+                    systemPrompt: systemPrompt,
+                    developerPrompt: developerPrompt,
+                    toolsEnabled: toolsEnabled
+                )
+
+                for try await event in stream {
+                    guard !Task.isCancelled else { break }
+                    await MainActor.run {
+                        self.apply(event: event, to: placeholder.id)
+                    }
+                }
+
+                await MainActor.run {
+                    self.finishStreaming(messageID: placeholder.id)
+                }
+            } catch {
+                await MainActor.run {
+                    self.failStreaming(error: error, messageID: placeholder.id)
+                }
+            }
+        }
+    }
+
+    func cancelStreaming() {
+        streamTask?.cancel()
+        streamTask = nil
+        isStreaming = false
+        if let index = messages.lastIndex(where: { $0.isStreaming }) {
+            messages[index].isStreaming = false
+            messages[index].content += "\n\n_Cancelled by user._"
+        }
+    }
+
+    private func apply(event: ChatStreamEvent, to messageID: UUID) {
+        guard let index = messages.firstIndex(where: { $0.id == messageID }) else { return }
+        switch event.type {
+        case .delta:
+            if let delta = event.delta {
+                messages[index].content.append(delta)
+            }
+        case .done:
+            messages[index].isStreaming = false
+            isStreaming = false
+        case .error:
+            let errorText = event.errorDescription ?? "Unknown error"
+            messages[index].content = "**Error:** \(errorText)"
+            messages[index].isStreaming = false
+            isStreaming = false
+            lastError = errorText
+        case .toolCalls:
+            if let existing = messages[index].metadata["tool_calls"] {
+                messages[index].metadata["tool_calls"] = existing + "\n" + (event.raw.description)
+            } else {
+                messages[index].metadata["tool_calls"] = event.raw.description
+            }
+        case .toolResult:
+            if let output = event.raw["output"]?.stringValue {
+                messages[index].metadata["tool_result"] = output
+            }
+        case .gateWarning:
+            let warning = event.message ?? "The model may not be allowed to answer."
+            messages[index].metadata["warning"] = warning
+        case .thinking, .message, .usage, .unknown:
+            break
+        }
+    }
+
+    private func finishStreaming(messageID: UUID) {
+        guard let index = messages.firstIndex(where: { $0.id == messageID }) else { return }
+        messages[index].isStreaming = false
+        if messages[index].content.isEmpty {
+            messages[index].content = "_(No response)_"
+        }
+        isStreaming = false
+    }
+
+    private func failStreaming(error: Error, messageID: UUID) {
+        guard let index = messages.firstIndex(where: { $0.id == messageID }) else { return }
+        let message = error.localizedDescription
+        messages[index].content = "**Error:** \(message)"
+        messages[index].isStreaming = false
+        lastError = message
+        isStreaming = false
+    }
+
+    func refreshHealth() async {
+        do {
+            let status = try await chatService.health()
+            await MainActor.run {
+                self.healthStatus = status
+                if let model = status.model, !model.isEmpty {
+                    self.selectedModel = model
+                }
+            }
+        } catch {
+            await MainActor.run {
+                self.healthStatus = HealthStatus(ok: false, ollama: backendConfiguration.baseURL.absoluteString, model: nil)
+                self.lastError = error.localizedDescription
+            }
+        }
+    }
+
+    func refreshModels() async {
+        do {
+            let items = try await chatService.fetchModels()
+            await MainActor.run {
+                self.models = items.sorted { $0.name < $1.name }
+            }
+        } catch {
+            await MainActor.run {
+                self.lastError = error.localizedDescription
+            }
+        }
+    }
+
+    func applyModel(tag: String) async {
+        do {
+            let applied = try await chatService.setModel(tag: tag)
+            await MainActor.run {
+                self.selectedModel = applied
+                Task { await self.refreshHealth() }
+            }
+        } catch {
+            await MainActor.run {
+                self.lastError = error.localizedDescription
+            }
+        }
+    }
+
+    func updateBackendURL(_ url: URL) {
+        backendConfiguration.baseURL = url
+        Task { await chatService.update(baseURL: url) }
+        Task { await refreshHealth() }
+    }
+
+    func toggleAutoLaunch(_ enabled: Bool) {
+        backendConfiguration.autoLaunchBackend = enabled
+    }
+
+    func setPythonInterpreter(_ url: URL?) {
+        backendConfiguration.pythonInterpreter = url
+    }
+
+    func startPythonBackend() {
+        guard let python = backendConfiguration.pythonInterpreter else {
+            lastError = "Select a Python interpreter before launching the backend."
+            return
+        }
+        Task { await pythonManager.start(pythonInterpreter: python) }
+    }
+
+    func stopPythonBackend() {
+        pythonManager.stop()
+    }
+
+    private func persistConfiguration() {
+        do {
+            let data = try JSONEncoder().encode(backendConfiguration)
+            try data.write(to: configurationURL, options: .atomic)
+        } catch {
+            lastError = "Failed to persist configuration: \(error.localizedDescription)"
+        }
+    }
+
+    private static func loadConfiguration(from url: URL) -> BackendConfiguration? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(BackendConfiguration.self, from: data)
+    }
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/BestAIProjectApp.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/BestAIProjectApp.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+@main
+struct BestAIProjectApp: App {
+    private let appState: AppState
+
+    init() {
+        let rootURL = BestAIProjectApp.locateProjectRoot()
+        self.appState = AppState(projectRoot: rootURL)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(appState: appState)
+        }
+        .windowStyle(.automatic)
+    }
+
+    private static func locateProjectRoot() -> URL {
+        let fileManager = FileManager.default
+        let candidates: [URL] = [
+            URL(fileURLWithPath: fileManager.currentDirectoryPath),
+            Bundle.main.bundleURL,
+            Bundle.main.bundleURL.deletingLastPathComponent(),
+            Bundle.main.bundleURL.deletingLastPathComponent().deletingLastPathComponent()
+        ]
+
+        for candidate in candidates {
+            let path = candidate.appendingPathComponent("server.py").path
+            if fileManager.fileExists(atPath: path) {
+                return candidate
+            }
+        }
+
+        // Fallback to current directory
+        return URL(fileURLWithPath: fileManager.currentDirectoryPath)
+    }
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/Models.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/Models.swift
@@ -1,0 +1,262 @@
+import Foundation
+
+enum ChatRole: String, Codable, CaseIterable, Identifiable {
+    case system
+    case user
+    case assistant
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .system: return "System"
+        case .user: return "You"
+        case .assistant: return "Assistant"
+        }
+    }
+}
+
+struct ChatMessage: Identifiable, Codable, Equatable {
+    let id: UUID
+    var role: ChatRole
+    var content: String
+    var createdAt: Date
+    var isStreaming: Bool
+    var metadata: [String: String]
+
+    init(
+        id: UUID = UUID(),
+        role: ChatRole,
+        content: String,
+        createdAt: Date = Date(),
+        isStreaming: Bool = false,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.createdAt = createdAt
+        self.isStreaming = isStreaming
+        self.metadata = metadata
+    }
+
+    var formattedTimestamp: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter.string(from: createdAt)
+    }
+
+    var payload: MessagePayload {
+        MessagePayload(role: role.rawValue, content: content)
+    }
+}
+
+struct MessagePayload: Codable, Equatable {
+    var role: String
+    var content: String
+}
+
+struct ChatSettings: Codable, Equatable {
+    var dynamicContext: Bool = true
+    var maxContext: Int = 40_000
+    var numContext: Int = 8_192
+    var temperature: Double = 0.9
+    var topP: Double = 0.9
+    var topK: Int = 100
+    var numPredict: Int?
+    var seed: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case dynamicContext = "dynamic_ctx"
+        case maxContext = "max_ctx"
+        case numContext = "num_ctx"
+        case temperature
+        case topP = "top_p"
+        case topK = "top_k"
+        case numPredict = "num_predict"
+        case seed
+    }
+}
+
+enum StreamEventType: String, Decodable {
+    case delta
+    case done
+    case error
+    case toolCalls = "tool_calls"
+    case toolResult = "tool_result"
+    case gateWarning = "gate_warning"
+    case thinking
+    case message
+    case usage
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        self = StreamEventType(rawValue: raw) ?? .unknown
+    }
+}
+
+struct ChatStreamEvent: Decodable, Identifiable {
+    let id = UUID()
+    let type: StreamEventType
+    let raw: [String: JSONValue]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let dictionary = try container.decode([String: JSONValue].self)
+        raw = dictionary
+        if let explicitType = dictionary["type"]?.stringValue,
+           let mapped = StreamEventType(rawValue: explicitType) {
+            type = mapped
+        } else if dictionary["delta"] != nil {
+            type = .delta
+        } else {
+            type = .unknown
+        }
+    }
+
+    var delta: String? { raw["delta"]?.stringValue }
+    var message: String? { raw["message"]?.stringValue ?? raw["content"]?.stringValue }
+    var role: String? { raw["role"]?.stringValue }
+    var usage: [String: JSONValue]? { raw["usage"]?.dictionaryValue }
+
+    var errorDescription: String? {
+        guard type == .error else { return nil }
+        return raw["message"]?.stringValue
+    }
+}
+
+enum JSONValue: Equatable {
+    case string(String)
+    case number(Double)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case bool(Bool)
+    case null
+}
+
+extension JSONValue: Decodable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let double = try? container.decode(Double.self) {
+            self = .number(double)
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let array = try? container.decode([JSONValue].self) {
+            self = .array(array)
+        } else if let dictionary = try? container.decode([String: JSONValue].self) {
+            self = .object(dictionary)
+        } else {
+            throw DecodingError.typeMismatch(
+                JSONValue.self,
+                DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unsupported JSON value")
+            )
+        }
+    }
+}
+
+extension JSONValue {
+    var stringValue: String? {
+        if case let .string(value) = self { return value }
+        return nil
+    }
+
+    var doubleValue: Double? {
+        if case let .number(value) = self { return value }
+        return nil
+    }
+
+    var intValue: Int? {
+        if case let .number(value) = self { return Int(value) }
+        return nil
+    }
+
+    var boolValue: Bool? {
+        if case let .bool(value) = self { return value }
+        return nil
+    }
+
+    var arrayValue: [JSONValue]? {
+        if case let .array(value) = self { return value }
+        return nil
+    }
+
+    var dictionaryValue: [String: JSONValue]? {
+        if case let .object(value) = self { return value }
+        return nil
+    }
+}
+
+struct HealthStatus: Decodable {
+    var ok: Bool
+    var ollama: String?
+    var model: String?
+}
+
+struct ModelsResponse: Decodable {
+    var models: [ModelSummary]
+}
+
+struct ModelSummary: Decodable, Identifiable, Hashable {
+    var id: String { name }
+    var name: String
+    var size: String
+    var details: ModelDetails?
+    var modifiedAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case size
+        case details
+        case modifiedAt = "modified_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        size = try container.decodeIfPresent(String.self, forKey: .size) ?? ""
+        details = try container.decodeIfPresent(ModelDetails.self, forKey: .details)
+        if let modifiedString = try container.decodeIfPresent(String.self, forKey: .modifiedAt) {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            modifiedAt = formatter.date(from: modifiedString) ?? ISO8601DateFormatter().date(from: modifiedString)
+        } else {
+            modifiedAt = nil
+        }
+    }
+}
+
+struct ModelDetails: Decodable, Hashable {
+    var parameterSize: String?
+    var quantizationLevel: String?
+
+    enum CodingKeys: String, CodingKey {
+        case parameterSize = "parameter_size"
+        case quantizationLevel = "quantization_level"
+    }
+}
+
+struct BackendConfiguration: Codable, Equatable {
+    var baseURL: URL
+    var autoLaunchBackend: Bool
+    var pythonInterpreter: URL?
+
+    static let `default` = BackendConfiguration(
+        baseURL: URL(string: "http://127.0.0.1:8000")!,
+        autoLaunchBackend: false,
+        pythonInterpreter: nil
+    )
+}
+
+struct PythonServerLogLine: Identifiable, Equatable {
+    let id = UUID()
+    let timestamp: Date
+    let message: String
+    let isError: Bool
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/Services/ChatService.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/Services/ChatService.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+private struct ChatStreamRequest: Encodable {
+    var messages: [MessagePayload]
+    var settings: ChatSettings
+    var system: String
+    var developer: String
+    var tools: Bool
+}
+
+actor ChatService {
+    private var baseURL: URL
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+    private let session: URLSession
+
+    init(baseURL: URL) {
+        self.baseURL = baseURL
+        self.decoder = JSONDecoder()
+        self.encoder = JSONEncoder()
+        self.encoder.outputFormatting = [.sortedKeys]
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 60 * 5
+        configuration.timeoutIntervalForResource = 60 * 10
+        configuration.httpAdditionalHeaders = ["Accept": "text/event-stream"]
+        self.session = URLSession(configuration: configuration)
+    }
+
+    func update(baseURL: URL) {
+        self.baseURL = baseURL
+    }
+
+    func health() async throws -> HealthStatus {
+        let url = baseURL.appendingPathComponent("api/health")
+        let (data, response) = try await session.data(from: url)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw URLError(.badServerResponse)
+        }
+        return try decoder.decode(HealthStatus.self, from: data)
+    }
+
+    func fetchModels() async throws -> [ModelSummary] {
+        let url = baseURL.appendingPathComponent("api/models")
+        let (data, response) = try await session.data(from: url)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw URLError(.badServerResponse)
+        }
+        let payload = try decoder.decode(ModelsResponse.self, from: data)
+        return payload.models
+    }
+
+    func setModel(tag: String) async throws -> String {
+        let url = baseURL.appendingPathComponent("api/models/set")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body = ["model": tag]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw URLError(.badServerResponse)
+        }
+        let object = try decoder.decode([String: String].self, from: data)
+        return object["model"] ?? tag
+    }
+
+    func stream(
+        history: [MessagePayload],
+        settings: ChatSettings,
+        systemPrompt: String,
+        developerPrompt: String,
+        toolsEnabled: Bool
+    ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+        let requestBody = ChatStreamRequest(
+            messages: history,
+            settings: settings,
+            system: systemPrompt,
+            developer: developerPrompt,
+            tools: toolsEnabled
+        )
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var request = URLRequest(url: baseURL.appendingPathComponent("api/chat/stream"))
+                    request.httpMethod = "POST"
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    request.httpBody = try encoder.encode(requestBody)
+
+                    let (bytes, response) = try await session.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+                        throw URLError(.badServerResponse)
+                    }
+
+                    var dataLines: [String] = []
+
+                    func flushBuffer() throws {
+                        guard !dataLines.isEmpty else { return }
+                        let payload = dataLines.joined(separator: "\n")
+                        dataLines.removeAll(keepingCapacity: true)
+
+                        if payload == "[DONE]" || payload.lowercased() == "done" {
+                            continuation.finish()
+                            return
+                        }
+
+                        let eventData = Data(payload.utf8)
+                        let event = try decoder.decode(ChatStreamEvent.self, from: eventData)
+                        continuation.yield(event)
+                    }
+
+                    for try await line in bytes.lines {
+                        if Task.isCancelled { break }
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if trimmed.isEmpty {
+                            try flushBuffer()
+                            continue
+                        }
+
+                        if trimmed.hasPrefix("data:") {
+                            let chunk = trimmed.dropFirst(5).trimmingCharacters(in: .whitespaces)
+                            if chunk.isEmpty { continue }
+                            dataLines.append(String(chunk))
+                        }
+                    }
+
+                    try flushBuffer()
+                    continuation.finish()
+                } catch {
+                    if Task.isCancelled { return }
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/Services/PythonServerManager.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/Services/PythonServerManager.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+@MainActor
+final class PythonServerManager: ObservableObject {
+    @Published private(set) var isRunning = false
+    @Published private(set) var logs: [PythonServerLogLine] = []
+    @Published private(set) var lastError: String?
+
+    private var process: Process?
+    private var stdoutPipe: Pipe?
+    private var stderrPipe: Pipe?
+    private var stdoutTask: Task<Void, Never>?
+    private var stderrTask: Task<Void, Never>?
+
+    let projectRoot: URL
+
+    init(projectRoot: URL) {
+        self.projectRoot = projectRoot
+    }
+
+    func start(pythonInterpreter: URL) async {
+        guard process == nil else { return }
+        lastError = nil
+
+        let process = Process()
+        process.currentDirectoryURL = projectRoot
+        process.executableURL = pythonInterpreter
+        process.arguments = ["server.py"]
+        process.environment = ProcessInfo.processInfo.environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+            self.process = process
+            self.stdoutPipe = stdoutPipe
+            self.stderrPipe = stderrPipe
+            isRunning = true
+            appendLog("Launched python server.py using \(pythonInterpreter.path)", isError: false)
+            observe(pipe: stdoutPipe, isError: false)
+            observe(pipe: stderrPipe, isError: true)
+
+            process.terminationHandler = { [weak self] proc in
+                Task { @MainActor in
+                    self?.handleTermination(status: Int(proc.terminationStatus))
+                }
+            }
+        } catch {
+            appendLog("Failed to launch python: \(error.localizedDescription)", isError: true)
+            lastError = error.localizedDescription
+            cleanup()
+        }
+    }
+
+    func stop() {
+        guard let process else { return }
+        process.terminationHandler = nil
+        process.interrupt()
+        process.terminate()
+        appendLog("Stopping python backend…", isError: false)
+        cleanup()
+    }
+
+    private func handleTermination(status: Int) {
+        if status != 0 {
+            lastError = "Python backend exited with code \(status)"
+            appendLog("Python backend exited with code \(status)", isError: true)
+        } else {
+            appendLog("Python backend exited", isError: false)
+        }
+        cleanup()
+    }
+
+    private func observe(pipe: Pipe, isError: Bool) {
+        let handle = pipe.fileHandleForReading
+        let task = Task { [weak self] in
+            do {
+                for try await line in handle.bytes.lines {
+                    guard !Task.isCancelled else { break }
+                    await MainActor.run {
+                        self?.appendLog(line, isError: isError)
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    self?.appendLog("Failed to read \(isError ? "stderr" : "stdout"): \(error.localizedDescription)", isError: true)
+                }
+            }
+        }
+
+        if isError {
+            stderrTask = task
+        } else {
+            stdoutTask = task
+        }
+    }
+
+    private func appendLog(_ message: String, isError: Bool) {
+        logs.append(PythonServerLogLine(timestamp: Date(), message: message, isError: isError))
+        if logs.count > 500 {
+            logs.removeFirst(logs.count - 500)
+        }
+    }
+
+    private func cleanup() {
+        stdoutTask?.cancel()
+        stderrTask?.cancel()
+        stdoutTask = nil
+        stderrTask = nil
+        stdoutPipe = nil
+        stderrPipe = nil
+        process = nil
+        isRunning = false
+    }
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/Support/MarkdownRenderer.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/Support/MarkdownRenderer.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftUI
+
+enum MarkdownRenderer {
+    static func attributedString(from markdown: String) -> AttributedString {
+        guard !markdown.isEmpty else { return AttributedString("") }
+        do {
+            return try AttributedString(
+                markdown: markdown,
+                options: AttributedString.MarkdownParsingOptions(
+                    interpretation: .full,
+                    appliesSourcePositionAttributes: false
+                )
+            )
+        } catch {
+            return AttributedString(markdown)
+        }
+    }
+
+    static func text(from markdown: String) -> Text {
+        Text(attributedString(from: markdown))
+    }
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/ChatComposerView.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/ChatComposerView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct ChatComposerView: View {
+    @Binding var text: String
+    var isStreaming: Bool
+    var sendAction: () -> Void
+    var cancelAction: () -> Void
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Divider()
+            HStack(alignment: .bottom, spacing: 12) {
+                TextEditor(text: $text)
+                    .focused($isFocused)
+                    .frame(minHeight: 80, maxHeight: 160)
+                    .overlay(alignment: .topLeading) {
+                        if text.isEmpty {
+                            Text("Type your message…")
+                                .foregroundStyle(.secondary)
+                                .padding(.top, 8)
+                                .padding(.leading, 6)
+                        }
+                    }
+                    .onSubmit(send)
+                    .background(Color(nsColor: .textBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                VStack(spacing: 8) {
+                    Button(action: send) {
+                        Label(isStreaming ? "Stop" : "Send", systemImage: isStreaming ? "stop.fill" : "paperplane.fill")
+                            .labelStyle(.titleAndIcon)
+                    }
+                    .keyboardShortcut(.return, modifiers: [.command])
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!isStreaming && text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    if isStreaming {
+                        Button("Cancel", action: cancelAction)
+                            .buttonStyle(.bordered)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 20)
+    }
+
+    private func send() {
+        if isStreaming {
+            cancelAction()
+        } else {
+            sendAction()
+        }
+    }
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/ChatMessageListView.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/ChatMessageListView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+struct ChatMessageListView: View {
+    let messages: [ChatMessage]
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    ForEach(messages) { message in
+                        ChatMessageBubble(message: message)
+                            .id(message.id)
+                    }
+                }
+                .padding(.vertical, 16)
+                .padding(.horizontal, 20)
+            }
+            .background(Color(nsColor: .textBackgroundColor))
+            .onChange(of: messages.last?.id) { id in
+                guard let id else { return }
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    proxy.scrollTo(id, anchor: .bottom)
+                }
+            }
+        }
+    }
+}
+
+private struct ChatMessageBubble: View {
+    let message: ChatMessage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(message.role.label.uppercased())
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(roleColor)
+                Spacer()
+                Text(message.formattedTimestamp)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            MarkdownRenderer.text(from: message.content.isEmpty ? "…" : message.content)
+                .font(.body)
+                .textSelection(.enabled)
+            if !message.metadata.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(message.metadata.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                        Text("\(key): \(value)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(8)
+                .background(Color(nsColor: .quaternaryLabelColor).opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            if message.isStreaming {
+                ProgressView()
+                    .scaleEffect(0.6, anchor: .leading)
+                    .padding(.top, 4)
+            }
+        }
+        .padding(16)
+        .background(bubbleBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private var bubbleBackground: some View {
+        switch message.role {
+        case .user:
+            return Color.accentColor.opacity(0.12)
+        case .assistant:
+            return Color.blue.opacity(0.1)
+        case .system:
+            return Color.gray.opacity(0.08)
+        }
+    }
+
+    private var roleColor: Color {
+        switch message.role {
+        case .user:
+            return .accentColor
+        case .assistant:
+            return .blue
+        case .system:
+            return .gray
+        }
+    }
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/ContentView.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/ContentView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var appState: AppState
+
+    init(appState: AppState) {
+        _appState = StateObject(wrappedValue: appState)
+    }
+
+    var body: some View {
+        NavigationSplitView {
+            SettingsSidebarView(appState: appState)
+                .frame(minWidth: 320)
+        } detail: {
+            VStack(spacing: 0) {
+                ChatMessageListView(messages: appState.messages)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                ChatComposerView(
+                    text: $appState.composerText,
+                    isStreaming: appState.isStreaming,
+                    sendAction: appState.send,
+                    cancelAction: appState.cancelStreaming
+                )
+                StatusFooterView(appState: appState)
+            }
+            .toolbar {
+                ToolbarItemGroup(placement: .automatic) {
+                    Button("Check health") {
+                        Task { await appState.refreshHealth() }
+                    }
+                    Button("Refresh models") {
+                        Task { await appState.refreshModels() }
+                    }
+                }
+            }
+        }
+        .onAppear { appState.onAppear() }
+        .alert(isPresented: Binding<Bool>(
+            get: { appState.lastError != nil },
+            set: { if !$0 { appState.lastError = nil } }
+        )) {
+            Alert(
+                title: Text("Error"),
+                message: Text(appState.lastError ?? "Unknown error"),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView(appState: AppState(projectRoot: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)))
+    }
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/SettingsSidebarView.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/SettingsSidebarView.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct SettingsSidebarView: View {
+    @ObservedObject var appState: AppState
+    @State private var backendURLString: String
+    @State private var pythonPath: String
+    @State private var showingPythonImporter = false
+
+    init(appState: AppState) {
+        self.appState = appState
+        _backendURLString = State(initialValue: appState.backendConfiguration.baseURL.absoluteString)
+        _pythonPath = State(initialValue: appState.backendConfiguration.pythonInterpreter?.path ?? "")
+    }
+
+    private var numPredictBinding: Binding<String> {
+        Binding<String>(
+            get: { appState.settings.numPredict.map(String.init) ?? "" },
+            set: { newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                appState.settings.numPredict = Int(trimmed)
+            }
+        )
+    }
+
+    private var seedBinding: Binding<String> {
+        Binding<String>(
+            get: { appState.settings.seed.map(String.init) ?? "" },
+            set: { newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                appState.settings.seed = Int(trimmed)
+            }
+        )
+    }
+
+    var body: some View {
+        Form {
+            Section("Backend") {
+                TextField("Base URL", text: $backendURLString)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit(applyBackendURL)
+                HStack {
+                    Button("Apply URL", action: applyBackendURL)
+                    Button("Refresh", action: { Task { await appState.refreshHealth() } })
+                }
+                if let status = appState.healthStatus {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Label(status.ok ? "Backend reachable" : "Backend unavailable", systemImage: status.ok ? "checkmark.seal" : "exclamationmark.triangle")
+                            .symbolVariant(.fill)
+                            .foregroundStyle(status.ok ? Color.green : Color.orange)
+                        if let model = status.model {
+                            Text("Active model: \(model)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        if let host = status.ollama {
+                            Text("Ollama host: \(host)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            Section("Models") {
+                if appState.models.isEmpty {
+                    Text("No models returned yet.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Picker("Select model", selection: $appState.selectedModel) {
+                        ForEach(appState.models) { model in
+                            Text(model.name).tag(model.name)
+                        }
+                    }
+                    .onChange(of: appState.selectedModel) { tag in
+                        guard !tag.isEmpty else { return }
+                        Task { await appState.applyModel(tag: tag) }
+                    }
+                }
+                Button("Refresh models") {
+                    Task { await appState.refreshModels() }
+                }
+            }
+
+            Section("Prompts") {
+                TextField("System prompt", text: $appState.systemPrompt, axis: .vertical)
+                    .lineLimit(3, reservesSpace: true)
+                TextField("Developer prompt", text: $appState.developerPrompt, axis: .vertical)
+                    .lineLimit(4, reservesSpace: true)
+            }
+
+            Section("Generation settings") {
+                Toggle("Enable tool calls", isOn: $appState.toolsEnabled)
+                Toggle("Dynamic context", isOn: $appState.settings.dynamicContext)
+                Stepper(value: $appState.settings.maxContext, in: 4096...80_000, step: 1024) {
+                    Text("Max context: \(appState.settings.maxContext)")
+                }
+                Stepper(value: $appState.settings.numContext, in: 4096...80_000, step: 512) {
+                    Text("Working context: \(appState.settings.numContext)")
+                }
+                VStack(alignment: .leading) {
+                    Text("Temperature: \(String(format: "%.2f", appState.settings.temperature))")
+                    Slider(value: $appState.settings.temperature, in: 0...1, step: 0.05)
+                }
+                VStack(alignment: .leading) {
+                    Text("Top P: \(String(format: "%.2f", appState.settings.topP))")
+                    Slider(value: $appState.settings.topP, in: 0...1, step: 0.05)
+                }
+                Stepper(value: $appState.settings.topK, in: 10...200, step: 5) {
+                    Text("Top K: \(appState.settings.topK)")
+                }
+                TextField("Max tokens (leave blank for default)", text: numPredictBinding)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Seed (optional)", text: seedBinding)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            Section("Python backend") {
+                Toggle("Launch Python backend on start", isOn: $appState.backendConfiguration.autoLaunchBackend)
+                HStack {
+                    TextField("Interpreter path", text: $pythonPath)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit(applyPythonPath)
+                    Button("Browse…") { showingPythonImporter = true }
+                }
+                HStack {
+                    Button(appState.pythonManager.isRunning ? "Restart" : "Launch") {
+                        if appState.pythonManager.isRunning {
+                            appState.stopPythonBackend()
+                            appState.startPythonBackend()
+                        } else {
+                            applyPythonPath()
+                            appState.startPythonBackend()
+                        }
+                    }
+                    Button("Stop") {
+                        appState.stopPythonBackend()
+                    }
+                    .disabled(!appState.pythonManager.isRunning)
+                }
+                if let error = appState.pythonManager.lastError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+                if !appState.pythonManager.logs.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Recent logs")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 2) {
+                                ForEach(appState.pythonManager.logs.suffix(8)) { line in
+                                    Text("\(line.timestamp.formatted(date: .omitted, time: .shortened))  •  \(line.message)")
+                                        .font(.caption2)
+                                        .foregroundStyle(line.isError ? Color.red : Color.secondary)
+                                }
+                            }
+                        }
+                        .frame(maxHeight: 120)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .onAppear {
+            backendURLString = appState.backendConfiguration.baseURL.absoluteString
+            pythonPath = appState.backendConfiguration.pythonInterpreter?.path ?? ""
+        }
+        .onReceive(appState.$backendConfiguration) { config in
+            backendURLString = config.baseURL.absoluteString
+            pythonPath = config.pythonInterpreter?.path ?? ""
+        }
+        .fileImporter(isPresented: $showingPythonImporter, allowedContentTypes: [.item], allowsMultipleSelection: false) { result in
+            switch result {
+            case .success(let urls):
+                guard let first = urls.first else { return }
+                pythonPath = first.path
+                appState.setPythonInterpreter(first)
+            case .failure(let error):
+                appState.lastError = error.localizedDescription
+            }
+        }
+    }
+
+    private func applyBackendURL() {
+        guard let url = URL(string: backendURLString.trimmingCharacters(in: .whitespaces)) else { return }
+        appState.updateBackendURL(url)
+    }
+
+    private func applyPythonPath() {
+        let trimmed = pythonPath.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            appState.setPythonInterpreter(nil)
+            return
+        }
+        let url = URL(fileURLWithPath: trimmed)
+        appState.setPythonInterpreter(url)
+    }
+}

--- a/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/StatusFooterView.swift
+++ b/macos/BestAIProjectApp/Sources/BestAIProjectApp/Views/StatusFooterView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct StatusFooterView: View {
+    @ObservedObject var appState: AppState
+
+    var body: some View {
+        HStack(spacing: 16) {
+            if let status = appState.healthStatus {
+                Label(
+                    status.ok ? "Backend OK" : "Backend unreachable",
+                    systemImage: status.ok ? "checkmark.circle" : "exclamationmark.triangle"
+                )
+                .foregroundStyle(status.ok ? Color.green : Color.orange)
+                if let model = status.model {
+                    Text("Model: \(model)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Label("Health unknown", systemImage: "questionmark.diamond")
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+                .frame(height: 20)
+
+            Label(appState.pythonManager.isRunning ? "Backend running" : "Backend stopped", systemImage: "terminal")
+                .foregroundStyle(appState.pythonManager.isRunning ? Color.green : Color.secondary)
+
+            if let error = appState.lastError {
+                Divider().frame(height: 20)
+                Label(error, systemImage: "bolt.trianglebadge.exclamationmark")
+                    .foregroundStyle(Color.red)
+                    .font(.caption)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .background(Color(nsColor: .windowBackgroundColor).opacity(0.95))
+    }
+}


### PR DESCRIPTION
## Summary
- add a Swift Package-based macOS app scaffold and documentation for editing the project in Xcode
- implement chat state management, SSE networking, and SwiftUI views that mirror the FastAPI backend features
- integrate a Python backend process manager so the macOS client can launch and monitor server.py directly

## Testing
- not run (Swift toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d19ae0acc48323a75535742535943c